### PR TITLE
Be able to send prop component without parens

### DIFF
--- a/react.js
+++ b/react.js
@@ -29,7 +29,18 @@ module.exports = {
     "react/state-in-constructor": 0,
     "react/jsx-no-useless-fragment": 1,
     "react/jsx-pascal-case": 2,
-    "react/jsx-wrap-multilines": 2,
+    "react/jsx-wrap-multilines": [
+      "error",
+      {
+        declaration: "parens",
+        assignment: "parens",
+        return: "parens",
+        arrow: "parens",
+        condition: "parens",
+        logical: "parens",
+        prop: "ignore",
+      },
+    ],
   },
   globals: {
     __DEV__: true,


### PR DESCRIPTION
Fix for this error: 

<img width="567" alt="Screenshot 2022-07-25 at 16 51 21" src="https://user-images.githubusercontent.com/23479568/180806298-e432931a-efe2-4ea2-9210-76df65975b3a.png">
